### PR TITLE
Fix script for Chatbox to work with Turbolinks 5

### DIFF
--- a/lib/zopim_rails/chatbox.rb
+++ b/lib/zopim_rails/chatbox.rb
@@ -4,7 +4,7 @@ module ZopimRails
   class Chatbox
     def render_script
       <<-JAVASCRIPT
-      <script type="text/javascript">function zopim_chat(){$('[__jx__id]').remove();window.$zopim = null;(function(d,s){var z=$zopim=function(c){z._.push(c)},$=z.s=d.createElement(s),e=d.getElementsByTagName(s)[0];z.set=function(o){z.set._.push(o)};z._=[];z.set._=[];$.async=!0;$.setAttribute('charset','utf-8');$.src='//v2.zopim.com/?#{ZopimRails.configuration.api_key}';z.t=+new Date;$.type='text/javascript';e.parentNode.insertBefore($,e)})(document,'script')};$(window).off('page:change.zopim').on('page:change.zopim', zopim_chat);</script>
+      <script type="text/javascript">function zopim_chat(){$('[__jx__id]').remove();window.$zopim = null;(function(d,s){var z=$zopim=function(c){z._.push(c)},$=z.s=d.createElement(s),e=d.getElementsByTagName(s)[0];z.set=function(o){z.set._.push(o)};z._=[];z.set._=[];$.async=!0;$.setAttribute('charset','utf-8');$.src='//v2.zopim.com/?#{ZopimRails.configuration.api_key}';z.t=+new Date;$.type='text/javascript';e.parentNode.insertBefore($,e)})(document,'script')};$(window).off('page:change.zopim turbolinks:load.zopim').on('page:change.zopim turbolinks:load.zopim', zopim_chat);</script>
       JAVASCRIPT
     end
   end


### PR DESCRIPTION
This fix should resolve #10 .

Turbolinks 5 has renamed some of the events in Turbolinks Classic. In this case, `page:change` is now `turbolinks:load` in Turbolinks 5.

Note that I did not remove the `page:change` event as it doesn't seem to work with Turbolinks Classic after its removal even though Turbolinks 5 includes a backward compatible shim [here](https://github.com/turbolinks/turbolinks/blob/master/src/turbolinks/compatibility.coffee)
